### PR TITLE
Fix method override hack

### DIFF
--- a/Distribution/Server/Util/Happstack.hs
+++ b/Distribution/Server/Util/Happstack.hs
@@ -35,7 +35,7 @@ import System.IO.Unsafe (unsafePerformIO)
 -- method of a request. Useful until we can standardise on HTML 5.
 methodOverrideHack :: MonadIO m => ServerPartT m a -> ServerPartT m a
 methodOverrideHack rest
-  = withDataFn (readM "_method") $ \mthd ->
+  = withDataFn (readM =<< look "_method") $ \mthd ->
       localRq (\req -> req { rqMethod = mthd }) rest
 
 -- | For use with 'methodOverrideHack': tries to report the original method


### PR DESCRIPTION
Previously the code attempted to (read "_method" :: Method). This
clearly fails as "_method" is not an HTTP method. I believe the author
intended (read $ look "_method"). It's strange that this wasn't caught
until now.
